### PR TITLE
add babel-register to devDependencies

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -82,6 +82,7 @@ module.exports = yeoman.generators.Base.extend({
       main: 'lib/index.js',
       devDependencies: {
         'babel-cli': '^6.4.5',
+        'babel-core': '^6.0.0',
         'babel-preset-es2015': '^6.3.13',
         'babel-preset-stage-0': '^6.3.13',
         'babel-register': '^6.0.0',

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -84,6 +84,7 @@ module.exports = yeoman.generators.Base.extend({
         'babel-cli': '^6.4.5',
         'babel-preset-es2015': '^6.3.13',
         'babel-preset-stage-0': '^6.3.13',
+        'babel-register': '^6.0.0',
         mocha: '^2.2.5'
       },
       "scripts": {


### PR DESCRIPTION
not in npm 2 (although we aren't recommending it anyway)

Since we do

```
 "test": "mocha --compilers js:babel-register",
```

below