### PR TITLE
prefer native trim() method

### DIFF
--- a/generators/app/templates/test/index.js
+++ b/generators/app/templates/test/index.js
@@ -4,10 +4,6 @@ import assert from 'assert';
 import { transformFileSync } from 'babel-core';
 import plugin from '../src';
 
-function trim(str) {
-  return str.replace(/^\s+|\s+$/, '');
-}
-
 describe('<%= description %>', () => {
   const fixturesDir = path.join(__dirname, 'fixtures');
   fs.readdirSync(fixturesDir).map((caseName) => {
@@ -20,7 +16,7 @@ describe('<%= description %>', () => {
           path.join(fixtureDir, 'expected.js')
       ).toString();
 
-      assert.equal(trim(actual), trim(expected));
+      assert.equal(actual.trim(), expected.trim());
     });
   });
 });


### PR DESCRIPTION
Node 0.10 already have native `trim()`